### PR TITLE
重现 #6 的 bug

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -10,8 +10,10 @@ var Test = React.createClass({
     return {
       placement: 'right',
       trigger: {
-        hover: 1
-      }
+        focus: 1,
+        click: 1
+      },
+      transitionName: 'rc-tooltip-zoom'
     };
   },
   onPlacementChange(e) {
@@ -45,6 +47,11 @@ var Test = React.createClass({
 
   preventDefault(e) {
     e.preventDefault();
+  },
+
+  test(e) {
+    e.preventDefault();
+    console.log(`// ${e.type}ed!`);
   },
 
   onVisibleChange(visible) {
@@ -90,7 +97,7 @@ var Test = React.createClass({
           onVisibleChange={this.onVisibleChange}
           overlay={<span>i am a tooltip</span>}
           transitionName={this.state.transitionName}>
-          <a href='#' style={{margin: 20}} onClick={this.preventDefault}>trigger</a>
+          <a href='#' style={{margin: 20}} onClick={this.test} onFocus={this.test}>trigger</a>
         </Tooltip>
       </div>
     </div>;

--- a/src/Tooltip.jsx
+++ b/src/Tooltip.jsx
@@ -78,6 +78,16 @@ class Tooltip extends React.Component {
 
   setVisible(visible) {
     if (this.state.visible !== visible) {
+      var now = Date.now();
+      console.log(this.lastVisibleChanged);
+      if (this.lastVisibleChanged &&
+          now - this.lastVisibleChanged < 30) {
+        // triggered too frequently so we should reject it
+        console.error('triggered too frequently but we pass it');
+        // console.info('// the patch works! :P');
+        // return;
+      }
+      this.lastVisibleChanged = now;
       this.setState({
         visible: visible
       });


### PR DESCRIPTION
`v2.3.0`，simple.js 的 demo 中，当勾选 `transitionName` 及 `focus` 和 `click` 后，连续点击 `trigger`，会随机发生 `focus` 和 `click` 连续触发（间隔非常短，一般只有不到 20ms）的情况，一般 `focus` 在前、`click` 在后，从而导致气泡弹出的一瞬间又收回了。

这里有两段录像展示，下载地址：  
http://pan.baidu.com/s/1c0FEp7U  
密码: 4rna

其中 bug-demo 为 bug 重现的录像，patched 为修正后的演示录像。  
请注意观察 console 中的时间和事件信息，其中记录了每次触发事件相应的事件名称，以及此时组件的状态。在有错误发生的地方会有红色字体的信息出现。

本 PR 中的代码即为错误演示代码，clone 下来后直接运行即可尝试。

（环境为 OS X 10.10.4 + Chrome 44 beta on MacBook Pro）