### PR TITLE
Implements topLeft topRight bottomLeft and bottomRight Popup placements

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ online example: http://react-component.github.io/tooltip/examples/
           <td>placement</td>
           <td>String|Object</td>
           <td></td>
-          <td>one of ['left','right','top','bottom'] or alignConfig of [dom-align](https://github.com/yiminghe/dom-align) </td>
+          <td>one of ['left','right','top','bottom', 'topLeft', 'topRight', 'bottomLeft', 'bottomRight'] or alignConfig of [dom-align](https://github.com/yiminghe/dom-align) </td>
         </tr>
         <tr>
           <td>overlay</td>

--- a/assets/bootstrap.less
+++ b/assets/bootstrap.less
@@ -42,6 +42,34 @@
       }
     }
 
+    &-topRight {
+
+      margin-top: -3px;
+      padding: 5px 0;
+
+      & > .@{tooltipPrefixCls}-arrow {
+        bottom: 0;
+        left: 85%;
+        margin-left: -5px;
+        border-width: 5px 5px 0;
+        border-top-color: #000000;
+      }
+    }
+
+    &-topLeft {
+
+      margin-top: -3px;
+      padding: 5px 0;
+
+      & > .@{tooltipPrefixCls}-arrow {
+        bottom: 0;
+        left: 15%;
+        margin-left: -5px;
+        border-width: 5px 5px 0;
+        border-top-color: #000000;
+      }
+    }
+
     &-bottom {
       margin-top: 3px;
       padding: 5px 0;
@@ -54,6 +82,34 @@
         border-bottom-color: #000000;
       }
 
+    }
+
+    &-bottomRight {
+
+      margin-top: 3px;
+      padding: 5px 0;
+
+      & > .@{tooltipPrefixCls}-arrow {
+        top: 0;
+        left: 85%;
+        margin-left: -5px;
+        border-width: 0 5px 5px;
+        border-bottom-color: #000000;
+      }
+    }
+
+    &-bottomLeft {
+
+      margin-top: 3px;
+      padding: 5px 0;
+
+      & > .@{tooltipPrefixCls}-arrow {
+        top: 0;
+        left: 15%;
+        margin-left: -5px;
+        border-width: 0 5px 5px;
+        border-bottom-color: #000000;
+      }
     }
 
     &-right {

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -58,6 +58,10 @@ var Test = React.createClass({
             <option>right</option>
             <option>top</option>
             <option>bottom</option>
+            <option>topLeft</option>
+            <option>topRight</option>
+            <option>bottomRight</option>
+            <option>bottomLeft</option>
           </select>
         </label>
         &nbsp;&nbsp;&nbsp;&nbsp;

--- a/src/Popup.jsx
+++ b/src/Popup.jsx
@@ -8,6 +8,10 @@ const placementAlignMap = {
   right: {points: ['cl', 'cr']},
   top: {points: ['bc', 'tc']},
   bottom: {points: ['tc', 'bc']},
+  topLeft: { points: ['bl', 'tl'] },
+  topRight: { points: ['br', 'tr'] },
+  bottomRight: { points: ['tr', 'br'] },
+  bottomLeft: { points: ['tl', 'bl'] }
 };
 
 const Popup = React.createClass({

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -125,6 +125,46 @@ describe('rc-tooltip', function () {
       }, 20);
     });
 
+    it('bottomRight works', (done)=> {
+      var tooltip = React.render(<Tooltip trigger={['click']} placement="bottomRight" overlay={<strong>tooltip</strong>}>
+        <div className="target">click</div>
+      </Tooltip>, div);
+      var domNode = React.findDOMNode(tooltip).firstChild;
+      Simulate.click(domNode);
+      setTimeout(()=> {
+        var popupDomNode = tooltip.getPopupDomNode();
+        expect(popupDomNode).to.be.ok();
+        var targetOffset = $(domNode).offset();
+        var popupOffset = $(popupDomNode).offset();
+        var arrowOffset = $(popupDomNode).find('.rc-tooltip-arrow').offset();
+        console.log(popupOffset, targetOffset);
+        expect(popupOffset.top).to.be(targetOffset.top + $(domNode).outerHeight());
+        expect(arrowOffset.left).to.be(180);
+        Simulate.click(domNode);
+        done();
+      }, 20);
+    });
+
+    it('bottomLeft works', (done)=> {
+      var tooltip = React.render(<Tooltip trigger={['click']} placement="bottomLeft" overlay={<strong>tooltip</strong>}>
+        <div className="target">click</div>
+      </Tooltip>, div);
+      var domNode = React.findDOMNode(tooltip).firstChild;
+      Simulate.click(domNode);
+      setTimeout(()=> {
+        var popupDomNode = tooltip.getPopupDomNode();
+        expect(popupDomNode).to.be.ok();
+        var targetOffset = $(domNode).offset();
+        var popupOffset = $(popupDomNode).offset();
+        var arrowOffset = $(popupDomNode).find('.rc-tooltip-arrow').offset();
+        console.log(popupOffset, targetOffset);
+        expect(popupOffset.top).to.be(targetOffset.top + $(domNode).outerHeight());
+        expect(arrowOffset.left).to.be(110);
+        Simulate.click(domNode);
+        done();
+      }, 20);
+    });
+
     it('top works', (done)=> {
       var tooltip = React.render(<Tooltip trigger={['click']} placement="top" overlay={<strong>tooltip</strong>}>
         <div className="target">click</div>
@@ -138,6 +178,48 @@ describe('rc-tooltip', function () {
         var popupOffset = $(popupDomNode).offset();
         console.log(popupOffset, targetOffset);
         expect(popupOffset.top).to.be(targetOffset.top - $(popupDomNode).outerHeight());
+        Simulate.click(domNode);
+        done();
+      }, 20);
+    });
+
+    it('topLeft works', (done)=> {
+      var tooltip = React.render(<Tooltip trigger={['click']} placement="topLeft" overlay={<strong>tooltip</strong>}>
+        <div className="target">click</div>
+      </Tooltip>, div);
+      var domNode = React.findDOMNode(tooltip).firstChild;
+      Simulate.click(domNode);
+      setTimeout(()=> {
+        var popupDomNode = tooltip.getPopupDomNode();
+        expect(popupDomNode).to.be.ok();
+        var targetOffset = $(domNode).offset();
+        var popupOffset = $(popupDomNode).offset();
+        var arrowOffset = $(popupDomNode).find('.rc-tooltip-arrow').offset();
+        console.log(popupOffset, targetOffset);
+        expect(popupOffset.top).to.be(targetOffset.top - $(popupDomNode).outerHeight());
+        expect(popupOffset.left).to.be(targetOffset.left);
+        expect(arrowOffset.left).to.be(110);
+        Simulate.click(domNode);
+        done();
+      }, 20);
+    });
+
+    it('topRight works', (done)=> {
+      var tooltip = React.render(<Tooltip trigger={['click']} placement="topRight" overlay={<strong>tooltip</strong>}>
+        <div className="target">click</div>
+      </Tooltip>, div);
+      var domNode = React.findDOMNode(tooltip).firstChild;
+      Simulate.click(domNode);
+      setTimeout(()=> {
+        var popupDomNode = tooltip.getPopupDomNode();
+        expect(popupDomNode).to.be.ok();
+        var targetOffset = $(domNode).offset();
+        var popupOffset = $(popupDomNode).offset();
+        var arrowOffset = $(popupDomNode).find('.rc-tooltip-arrow').offset();
+        console.log(popupOffset, targetOffset);
+        expect(popupOffset.top).to.be(targetOffset.top - $(popupDomNode).outerHeight());
+        expect(popupOffset.left).to.be(targetOffset.left);
+        expect(arrowOffset.left).to.be(180);
         Simulate.click(domNode);
         done();
       }, 20);


### PR DESCRIPTION
Implements 4 new positions for the popup:

topLeft:
![screen shot 2015-10-07 at 4 50 05 pm](https://cloud.githubusercontent.com/assets/1238532/10350709/9a265532-6d13-11e5-8074-e5156ca8fd16.png)

topRight:
![screen shot 2015-10-07 at 4 50 11 pm](https://cloud.githubusercontent.com/assets/1238532/10350719/a01f0812-6d13-11e5-8ec2-62ee84292d0c.png)

bottomLeft:
![screen shot 2015-10-07 at 4 50 19 pm](https://cloud.githubusercontent.com/assets/1238532/10350724/a4ca36fc-6d13-11e5-917f-fe6c098d5ecd.png)

bottomRight:
![screen shot 2015-10-07 at 4 50 15 pm](https://cloud.githubusercontent.com/assets/1238532/10350728/aa5025f0-6d13-11e5-9d3b-05453f6c6955.png)
