### PR TITLE
Upgrade to React 0.14: Fixes a context issue as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ tooltip ui component for react
 ```js
 var Tooltip = require('rc-tooltip');
 var React = require('react');
-React.render(<Tooltip placement="left" trigger={['click']} overlay={<span>tooltip</span>}><a href='#'>hover</a></Tooltip>, container);
+var ReactDOM = require('react-dom')
+ReactDOM.render(<Tooltip placement="left" trigger={['click']} overlay={<span>tooltip</span>}><a href='#'>hover</a></Tooltip>, container);
 ```
 
 ## Example

--- a/examples/formError.js
+++ b/examples/formError.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import ReactDOM from 'react-dom';
 import Tooltip from 'rc-tooltip';
 import 'rc-tooltip/assets/bootstrap.less';
 
@@ -40,4 +41,4 @@ var Test = React.createClass({
   }
 });
 
-React.render(<Test/>, document.getElementById("__react-content"));
+ReactDOM.render(<Test/>, document.getElementById("__react-content"));

--- a/examples/handleVisibleChange.js
+++ b/examples/handleVisibleChange.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import ReactDOM from 'react-dom';
 import Tooltip from 'rc-tooltip';
 import 'rc-tooltip/assets/bootstrap.less';
 
@@ -44,4 +45,4 @@ function preventDefault(e) {
   e.preventDefault();
 }
 
-React.render(<Test/>, document.getElementById("__react-content"));
+ReactDOM.render(<Test/>, document.getElementById("__react-content"));

--- a/examples/points.js
+++ b/examples/points.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import ReactDOM from 'react-dom';
 import Tooltip from 'rc-tooltip';
 import 'rc-tooltip/assets/bootstrap.less';
 
@@ -57,4 +58,4 @@ function preventDefault(e) {
   e.preventDefault();
 }
 
-React.render(<Test/>, document.getElementById("__react-content"));
+ReactDOM.render(<Test/>, document.getElementById("__react-content"));

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import ReactDOM from 'react-dom';
 import Tooltip from 'rc-tooltip';
 import 'rc-tooltip/assets/bootstrap.less';
 import assign from 'object-assign';
@@ -103,6 +104,6 @@ var Test = React.createClass({
   }
 });
 
-React.render(<div>
+ReactDOM.render(<div>
   <Test />
 </div>, document.getElementById("__react-content"));

--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
     "precommit-hook": "^1.0.7",
     "rc-server": "3.x",
     "rc-tools": "4.x",
-    "react": "^0.13.0"
+    "react": "^0.14.0",
+    "react-addons-test-utils": "^0.14.0",
+    "react-dom": "^0.14.0"
   },
   "precommit": [
     "lint"

--- a/src/Popup.jsx
+++ b/src/Popup.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import {getToolTipClassByPlacement, fromPointsToPlacement, placementAlignMap} from './utils';
 import Align from 'rc-align';
 import Animate from 'rc-animate';
@@ -39,11 +40,11 @@ const Popup = React.createClass({
   },
 
   getPopupDomNode() {
-    return React.findDOMNode(this);
+    return ReactDOM.findDOMNode(this);
   },
 
   getTarget() {
-    return React.findDOMNode(this.props.wrap).firstChild;
+    return ReactDOM.findDOMNode(this.props.wrap).firstChild;
   },
 
   getTransitionName() {

--- a/src/Tooltip.jsx
+++ b/src/Tooltip.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import {createChainedFunction, Dom} from 'rc-util';
 import Popup from './Popup';
 
@@ -61,8 +62,8 @@ const Tooltip = React.createClass({
     const state = this.state;
     if (this.popupRendered) {
       const self = this;
-      React.render(this.getPopupElement(), this.getTipContainer(), function renderPopup() {
-        self.popupDomNode = React.findDOMNode(this);
+      ReactDOM.unstable_renderSubtreeIntoContainer(this, this.getPopupElement(), this.getTipContainer(), function renderPopup() {
+        self.popupDomNode = ReactDOM.findDOMNode(this);
         if (prevState.visible !== state.visible) {
           props.afterVisibleChange(state.visible);
         }
@@ -88,7 +89,7 @@ const Tooltip = React.createClass({
   componentWillUnmount() {
     const tipContainer = this.tipContainer;
     if (tipContainer) {
-      React.unmountComponentAtNode(tipContainer);
+      ReactDOM.unmountComponentAtNode(tipContainer);
       if (this.props.getTooltipContainer) {
         const mountNode = this.props.getTooltipContainer();
         mountNode.removeChild(tipContainer);
@@ -162,7 +163,7 @@ const Tooltip = React.createClass({
 
   onDocumentClick(e) {
     const target = e.target;
-    const root = React.findDOMNode(this);
+    const root = ReactDOM.findDOMNode(this);
     const popupNode = this.getPopupDomNode();
     if (!Dom.contains(root, target) && !Dom.contains(popupNode, target)) {
       this.setVisible(false);

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -1,8 +1,9 @@
 'use strict';
 
 var expect = require('expect.js');
-var React = require('react/addons');
-var TestUtils = React.addons.TestUtils;
+var React = require('react');
+var ReactDOM = require('react-dom');
+var TestUtils = require('react-addons-test-utils');
 var Simulate = TestUtils.Simulate;
 var $ = require('jquery');
 window.$ = $;
@@ -25,16 +26,16 @@ describe('rc-tooltip', function () {
   document.body.insertBefore(div, document.body.firstChild);
 
   afterEach(()=> {
-    React.unmountComponentAtNode(div);
+    ReactDOM.unmountComponentAtNode(div);
   });
 
   describe('trigger', ()=> {
     it('click works', (done)=> {
-      var tooltip = React.render(<Tooltip trigger={['click']} placement="left"
+      var tooltip = ReactDOM.render(<Tooltip trigger={['click']} placement="left"
                                           overlay={<strong className='x-content'>tooltip2</strong>}>
         <div className="target">click</div>
       </Tooltip>, div);
-      var domNode = React.findDOMNode(tooltip).firstChild;
+      var domNode = ReactDOM.findDOMNode(tooltip).firstChild;
       Simulate.click(domNode);
       async.series([timeout(20), (next)=> {
         var popupDomNode = tooltip.getPopupDomNode();
@@ -50,7 +51,7 @@ describe('rc-tooltip', function () {
     });
 
     it('hover works', (done)=> {
-      var tooltip = React.render(<Tooltip trigger={['hover']}
+      var tooltip = ReactDOM.render(<Tooltip trigger={['hover']}
                                           placement="left"
                                           overlay={<strong>tooltip</strong>}>
         <div className="target">click</div>
@@ -73,12 +74,12 @@ describe('rc-tooltip', function () {
 
   describe('placement', ()=> {
     it('left works', (done)=> {
-      var tooltip = React.render(<Tooltip trigger={['click']} placement="left"
+      var tooltip = ReactDOM.render(<Tooltip trigger={['click']} placement="left"
                                           overlayStyle={{width:50}}
                                           overlay={<div>tooltip</div>}>
         <div className="target">click</div>
       </Tooltip>, div);
-      var domNode = React.findDOMNode(tooltip).firstChild;
+      var domNode = ReactDOM.findDOMNode(tooltip).firstChild;
       Simulate.click(domNode);
       setTimeout(()=> {
         var popupDomNode = tooltip.getPopupDomNode();
@@ -92,12 +93,12 @@ describe('rc-tooltip', function () {
     });
 
     it('auto adjust left works', (done)=> {
-      var tooltip = React.render(<Tooltip trigger={['click']} placement="left"
+      var tooltip = ReactDOM.render(<Tooltip trigger={['click']} placement="left"
                                           overlayStyle={{width:400}}
                                           overlay={<div>tooltip</div>}>
         <div className="target">click</div>
       </Tooltip>, div);
-      var domNode = React.findDOMNode(tooltip).firstChild;
+      var domNode = ReactDOM.findDOMNode(tooltip).firstChild;
       Simulate.click(domNode);
       setTimeout(()=> {
         var popupDomNode = tooltip.getPopupDomNode();
@@ -113,10 +114,10 @@ describe('rc-tooltip', function () {
     });
 
     it('right works', (done)=> {
-      var tooltip = React.render(<Tooltip trigger={['click']} placement="right" overlay={<strong>tooltip</strong>}>
+      var tooltip = ReactDOM.render(<Tooltip trigger={['click']} placement="right" overlay={<strong>tooltip</strong>}>
         <div className="target">click</div>
       </Tooltip>, div);
-      var domNode = React.findDOMNode(tooltip).firstChild;
+      var domNode = ReactDOM.findDOMNode(tooltip).firstChild;
       Simulate.click(domNode);
       setTimeout(()=> {
         var popupDomNode = tooltip.getPopupDomNode();
@@ -131,10 +132,10 @@ describe('rc-tooltip', function () {
     });
 
     it('bottom works', (done)=> {
-      var tooltip = React.render(<Tooltip trigger={['click']} placement="bottom" overlay={<strong>tooltip</strong>}>
+      var tooltip = ReactDOM.render(<Tooltip trigger={['click']} placement="bottom" overlay={<strong>tooltip</strong>}>
         <div className="target">click</div>
       </Tooltip>, div);
-      var domNode = React.findDOMNode(tooltip).firstChild;
+      var domNode = ReactDOM.findDOMNode(tooltip).firstChild;
       Simulate.click(domNode);
       setTimeout(()=> {
         var popupDomNode = tooltip.getPopupDomNode();
@@ -149,11 +150,11 @@ describe('rc-tooltip', function () {
     });
 
     it('bottomRight works', (done)=> {
-      var tooltip = React.render(<Tooltip trigger={['click']} placement="bottomRight"
+      var tooltip = ReactDOM.render(<Tooltip trigger={['click']} placement="bottomRight"
                                           overlay={<strong>tooltip</strong>}>
         <div className="target">click</div>
       </Tooltip>, div);
-      var domNode = React.findDOMNode(tooltip).firstChild;
+      var domNode = ReactDOM.findDOMNode(tooltip).firstChild;
       Simulate.click(domNode);
       setTimeout(()=> {
         var popupDomNode = tooltip.getPopupDomNode();
@@ -170,10 +171,10 @@ describe('rc-tooltip', function () {
     });
 
     it('bottomLeft works', (done)=> {
-      var tooltip = React.render(<Tooltip trigger={['click']} placement="bottomLeft" overlay={<strong>tooltip</strong>}>
+      var tooltip = ReactDOM.render(<Tooltip trigger={['click']} placement="bottomLeft" overlay={<strong>tooltip</strong>}>
         <div className="target">click</div>
       </Tooltip>, div);
-      var domNode = React.findDOMNode(tooltip).firstChild;
+      var domNode = ReactDOM.findDOMNode(tooltip).firstChild;
       Simulate.click(domNode);
       setTimeout(()=> {
         var popupDomNode = tooltip.getPopupDomNode();
@@ -190,10 +191,10 @@ describe('rc-tooltip', function () {
     });
 
     it('top works', (done)=> {
-      var tooltip = React.render(<Tooltip trigger={['click']} placement="top" overlay={<strong>tooltip</strong>}>
+      var tooltip = ReactDOM.render(<Tooltip trigger={['click']} placement="top" overlay={<strong>tooltip</strong>}>
         <div className="target">click</div>
       </Tooltip>, div);
-      var domNode = React.findDOMNode(tooltip).firstChild;
+      var domNode = ReactDOM.findDOMNode(tooltip).firstChild;
       Simulate.click(domNode);
       setTimeout(()=> {
         var popupDomNode = tooltip.getPopupDomNode();
@@ -208,10 +209,10 @@ describe('rc-tooltip', function () {
     });
 
     it('topLeft works', (done)=> {
-      var tooltip = React.render(<Tooltip trigger={['click']} placement="topLeft" overlay={<strong>tooltip</strong>}>
+      var tooltip = ReactDOM.render(<Tooltip trigger={['click']} placement="topLeft" overlay={<strong>tooltip</strong>}>
         <div className="target">click</div>
       </Tooltip>, div);
-      var domNode = React.findDOMNode(tooltip).firstChild;
+      var domNode = ReactDOM.findDOMNode(tooltip).firstChild;
       Simulate.click(domNode);
       setTimeout(()=> {
         var popupDomNode = tooltip.getPopupDomNode();
@@ -229,10 +230,10 @@ describe('rc-tooltip', function () {
     });
 
     it('topRight works', (done)=> {
-      var tooltip = React.render(<Tooltip trigger={['click']} placement="topRight" overlay={<strong>tooltip</strong>}>
+      var tooltip = ReactDOM.render(<Tooltip trigger={['click']} placement="topRight" overlay={<strong>tooltip</strong>}>
         <div className="target">click</div>
       </Tooltip>, div);
-      var domNode = React.findDOMNode(tooltip).firstChild;
+      var domNode = ReactDOM.findDOMNode(tooltip).firstChild;
       Simulate.click(domNode);
       setTimeout(()=> {
         var popupDomNode = tooltip.getPopupDomNode();
@@ -252,14 +253,14 @@ describe('rc-tooltip', function () {
 
   if (window.TransitionEvent) {
     it('transitionName works', (done)=> {
-      var tooltip = React.render(<Tooltip
+      var tooltip = ReactDOM.render(<Tooltip
         trigger={['click']}
         transitionName="fade"
         placement="top"
         overlay={<strong>tooltip</strong>}>
         <div className="target">click</div>
       </Tooltip>, div);
-      var domNode = React.findDOMNode(tooltip).firstChild;
+      var domNode = ReactDOM.findDOMNode(tooltip).firstChild;
       Simulate.click(domNode);
       async.series([
           timeout(100),


### PR DESCRIPTION
Context doesn't properly get carried over when using React 0.14

To solve this you need to upgrade the dependencies to React 0.14 and in Tooltip.jsx call ReactDOM.unstable_renderSubtreeIntoContainer instead of React.render.