### PR TITLE
Remove redundant object spread

### DIFF
--- a/src/Tooltip.jsx
+++ b/src/Tooltip.jsx
@@ -67,9 +67,8 @@ const Tooltip = React.createClass({
       placement, align,
       destroyTooltipOnHide,
       defaultVisible, getTooltipContainer,
-      ...restProps,
+      ...extraProps,
     } = this.props;
-    const extraProps = { ...restProps };
     if ('visible' in this.props) {
       extraProps.popupVisible = this.props.visible;
     }


### PR DESCRIPTION
`const extraProps = {...restProps}` is just cloning the restProps object to a variable with a new name. No need! Unless this was just a stylistic choice to make something more explicit?
