### PR TITLE
Change form of package.json property to singular

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "bugs": {
     "url": "http://github.com/react-component/tooltip/issues"
   },
-  "licenses": "MIT",
+  "license": "MIT",
   "config": {
     "port": 8007
   },


### PR DESCRIPTION
Since there's only one license the property should be of the singular
form.