### PR TITLE
Migrated deprecated React.PropTypes and React.createClass

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "lint"
   ],
   "dependencies": {
+    "create-react-class": "^15.5.2",
+    "prop-types": "^15.5.8",
     "rc-trigger": "1.x"
   }
 }

--- a/src/Tooltip.jsx
+++ b/src/Tooltip.jsx
@@ -1,8 +1,10 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import { placements } from './placements';
 import Trigger from 'rc-trigger';
 
-const Tooltip = React.createClass({
+const Tooltip = createReactClass({
   propTypes: {
     trigger: PropTypes.any,
     children: PropTypes.any,
@@ -14,8 +16,8 @@ const Tooltip = React.createClass({
     onVisibleChange: PropTypes.func,
     afterVisibleChange: PropTypes.func,
     overlay: PropTypes.oneOfType([
-      React.PropTypes.node,
-      React.PropTypes.func,
+      PropTypes.node,
+      PropTypes.func,
     ]).isRequired,
     overlayStyle: PropTypes.object,
     overlayClassName: PropTypes.string,


### PR DESCRIPTION
 - as React.PropTypes is being deprecated
 - Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.
 - Solution: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes