### PR TITLE
Added Screenreader-Support with ariaId

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Online examples: [http://react-component.github.io/tooltip/examples/](http://rea
           <td>whether destroy tooltip when tooltip is hidden</td>
         </tr>
         <tr>
-          <td>ariaId</td>
+          <td>id</td>
           <td>String</td>
           <td></td>
           <td>Id which gets attached to the tooltip content. Can be used with aria-describedby to achieve Screenreader-Support.</td>
@@ -189,6 +189,20 @@ Online examples: [http://react-component.github.io/tooltip/examples/](http://rea
 
 `Tooltip` requires child node accepts `onMouseEnter`, `onMouseLeave`, `onFocus`, `onClick` event.
 
+## Accessibility
+
+For accesibility purpose you can use the `id` prop to link your tooltip with another element. For example attaching it with an input:
+```jsx
+<Tooltip
+    ...
+    id={this.props.name}
+    <input className={className}
+           type="text"
+           ...
+           aria-describedby={this.props.name}/>
+</Tooltip>
+```
+If you do it like this, a screenreader would read the content of your tooltip if you focus the input element.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Online examples: [http://react-component.github.io/tooltip/examples/](http://rea
 
 ## Accessibility
 
-For accesibility purpose you can use the `id` prop to link your tooltip with another element. For example attaching it with an input:
+For accessibility purpose you can use the `id` prop to link your tooltip with another element. For example attaching it to an input element:
 ```jsx
 <Tooltip
     ...

--- a/README.md
+++ b/README.md
@@ -196,8 +196,7 @@ For accessibility purpose you can use the `id` prop to link your tooltip with an
 <Tooltip
     ...
     id={this.props.name}
-    <input className={className}
-           type="text"
+    <input type="text"
            ...
            aria-describedby={this.props.name}/>
 </Tooltip>

--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ Online examples: [http://react-component.github.io/tooltip/examples/](http://rea
           <td>false</td>
           <td>whether destroy tooltip when tooltip is hidden</td>
         </tr>
+        <tr>
+          <td>ariaId</td>
+          <td>String</td>
+          <td></td>
+          <td>Id which gets attached to the tooltip content. Can be used with aria-describedby to achieve Screenreader-Support.</td>
+        </tr>
     </tbody>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ For accessibility purpose you can use the `id` prop to link your tooltip with an
 ```jsx
 <Tooltip
     ...
-    id={this.props.name}
+    id={this.props.name}>
     <input type="text"
            ...
            aria-describedby={this.props.name}/>

--- a/src/Tooltip.jsx
+++ b/src/Tooltip.jsx
@@ -27,6 +27,7 @@ class Tooltip extends Component {
     destroyTooltipOnHide: PropTypes.bool,
     align: PropTypes.object,
     arrowContent: PropTypes.any,
+    ariaId: PropTypes.string
   };
 
   static defaultProps = {
@@ -46,7 +47,7 @@ class Tooltip extends Component {
       <div className={`${prefixCls}-arrow`} key="arrow">
         {arrowContent}
       </div>,
-      <div className={`${prefixCls}-inner`} key="content">
+      <div className={`${prefixCls}-inner`} key="content" id={this.props.ariaId}>
         {typeof overlay === 'function' ? overlay() : overlay}
       </div>,
     ]);

--- a/src/Tooltip.jsx
+++ b/src/Tooltip.jsx
@@ -27,7 +27,7 @@ class Tooltip extends Component {
     destroyTooltipOnHide: PropTypes.bool,
     align: PropTypes.object,
     arrowContent: PropTypes.any,
-    ariaId: PropTypes.string,
+    id: PropTypes.string,
   };
 
   static defaultProps = {
@@ -42,12 +42,12 @@ class Tooltip extends Component {
   };
 
   getPopupElement = () => {
-    const { arrowContent, overlay, prefixCls, ariaId } = this.props;
+    const { arrowContent, overlay, prefixCls, id } = this.props;
     return ([
       <div className={`${prefixCls}-arrow`} key="arrow">
         {arrowContent}
       </div>,
-      <div className={`${prefixCls}-inner`} key="content" id={ariaId}>
+      <div className={`${prefixCls}-inner`} key="content" id={id}>
         {typeof overlay === 'function' ? overlay() : overlay}
       </div>,
     ]);

--- a/src/Tooltip.jsx
+++ b/src/Tooltip.jsx
@@ -42,12 +42,12 @@ class Tooltip extends Component {
   };
 
   getPopupElement = () => {
-    const { arrowContent, overlay, prefixCls } = this.props;
+    const { arrowContent, overlay, prefixCls, ariaId } = this.props;
     return ([
       <div className={`${prefixCls}-arrow`} key="arrow">
         {arrowContent}
       </div>,
-      <div className={`${prefixCls}-inner`} key="content" id={this.props.ariaId}>
+      <div className={`${prefixCls}-inner`} key="content" id={ariaId}>
         {typeof overlay === 'function' ? overlay() : overlay}
       </div>,
     ]);

--- a/src/Tooltip.jsx
+++ b/src/Tooltip.jsx
@@ -27,7 +27,7 @@ class Tooltip extends Component {
     destroyTooltipOnHide: PropTypes.bool,
     align: PropTypes.object,
     arrowContent: PropTypes.any,
-    ariaId: PropTypes.string
+    ariaId: PropTypes.string,
   };
 
   static defaultProps = {


### PR DESCRIPTION
Added ariaId prop, which gets attached to the tooltips inner content container and can be used with aria-describedby for better accessibility and Screenreader-Support.