### PR TITLE
Update transitionName proptypes so it can be a string or object

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ Online examples: [http://react-component.github.io/tooltip/examples/](http://rea
         </tr>
         <tr>
           <td>transitionName</td>
-          <td>String</td>
+          <td>String|Object</td>
           <td></td>
-          <td>same as https://github.com/react-component/css-transition-group</td>
+          <td>same as https://github.com/react-component/animate</td>
         </tr>
         <tr>
           <td>onVisibleChange</td>

--- a/src/Tooltip.jsx
+++ b/src/Tooltip.jsx
@@ -10,7 +10,10 @@ class Tooltip extends Component {
     defaultVisible: PropTypes.bool,
     visible: PropTypes.bool,
     placement: PropTypes.string,
-    transitionName: PropTypes.string,
+    transitionName: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object,
+    ]),
     animation: PropTypes.any,
     onVisibleChange: PropTypes.func,
     afterVisibleChange: PropTypes.func,


### PR DESCRIPTION
Defined in: https://github.com/react-component/animate#props

I've also added a PR for rc-trigger: https://github.com/react-component/trigger/pull/70 that updates the outdated readme accordingly