### PR TITLE
Improve Tooltip example: Add onBlur event

### DIFF
--- a/examples/formError.js
+++ b/examples/formError.js
@@ -32,7 +32,10 @@ class Test extends Component {
             overlayStyle={{ zIndex: 1000 }}
             overlay={<span>required!</span>}
           >
-            <input onChange={this.handleChange}/>
+            <input
+              onChange={this.handleChange}
+              onBlur={this.handleChange}
+            />
           </Tooltip>
         </div>
         <button onClick={this.handleDestroy}>destroy</button>


### PR DESCRIPTION
Currently, we cannot see the Tooltip if the user just clicks the input and did not type anything.
I think it can be improved by adding onBlur event.