### PR TITLE
Update README.md to have clearer explanation about need for Tooltip to have correct child node

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,9 +195,9 @@ Online examples: <https://react-component.github.io/tooltip/examples/>
     </tbody>
 </table>
 
-## Note
+## Important Note
 
-`Tooltip` requires child node accepts `onMouseEnter`, `onMouseLeave`, `onFocus`, `onClick` event.
+`Tooltip` requires a child node that accepts an `onMouseEnter`, `onMouseLeave`, `onFocus`, `onClick` event. This means the child node must be a built-in component like `div` or `span`, or a custom component that passes its props to its built-in component child.
 
 ## Accessibility
 


### PR DESCRIPTION
This was brought up more than one time as an issue before, and I think updating the README to be slightly more clear may help prevent future questions about this.