### PR TITLE
chore: change children type to ReactNode

### DIFF
--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -32,7 +32,7 @@ export interface TooltipProps
   showArrow?: boolean | ArrowType;
   arrowContent?: React.ReactNode;
   id?: string;
-  children?: React.ReactElement;
+  children?: React.ReactNode;
   overlayInnerStyle?: React.CSSProperties;
   zIndex?: number;
 }


### PR DESCRIPTION
Using a string for a React component's `children` prop is a reasonable expectation for the component, and it is very common to use `React.ReactNode` as `children`'s type. This PR simply changes the type to allow the component more versatility without impacting the expectations of the `children` prop.

closes: https://github.com/react-component/tooltip/issues/292