### PR TITLE
fix: upgrade rc-trigger from 5.0.0 to 5.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@babel/runtime": "^7.11.2",
     "classnames": "^2.3.1",
-    "rc-trigger": "^5.0.0"
+    "rc-trigger": "^5.3.1"
   },
   "devDependencies": {
     "@types/jest": "^26.0.0",


### PR DESCRIPTION
An old version does not work well with react 18 / the page freezing while triggering tooltip visibility