### PR TITLE
delete opacity and background-color from base class

### DIFF
--- a/assets/bootstrap.less
+++ b/assets/bootstrap.less
@@ -13,7 +13,6 @@
 @tooltip-color: #fff;
 //** Tooltip background color
 @tooltip-bg: #373737;
-@tooltip-opacity: 0.9;
 
 //** Tooltip arrow width
 @tooltip-arrow-width: 5px;
@@ -33,7 +32,6 @@
   // top: -9999px;
   font-size: @font-size-base;
   line-height: @line-height-base;
-  opacity: @tooltip-opacity;
 
   &-hidden {
     display: none;

--- a/assets/bootstrap_white.less
+++ b/assets/bootstrap_white.less
@@ -13,7 +13,6 @@
 @tooltip-color: #333333;
 //** Tooltip background color
 @tooltip-bg: #ffffff;
-@tooltip-opacity: 0.9;
 
 @tooltip-border-width: 1px;
 @tooltip-border-color: #b1b1b1;
@@ -34,9 +33,7 @@
   visibility: visible;
   line-height: @line-height-base;
   font-size: @font-size-base;
-  background-color:rgba(0, 0, 0, 0.05);
   padding: @tooltip-shadow-width;
-  opacity: @tooltip-opacity;
 
   &-hidden {
     display: none;


### PR DESCRIPTION
I've fixed this issue  https://github.com/react-component/tooltip/issues/114 and also delete the `background-color` which was not so good looking on tooltip.