### PR TITLE
patch: export tooltip ref

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
-import Tooltip, { TooltipRef } from './Tooltip';
 import Popup from './Popup';
+import Tooltip from './Tooltip';
 
-export { Popup, TooltipRef };
+export type { TooltipRef } from './Tooltip';
+export { Popup };
 
 export default Tooltip;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
-import Tooltip from './Tooltip';
+import Tooltip, { TooltipRef } from './Tooltip';
 import Popup from './Popup';
 
-export { Popup };
+export { Popup, TooltipRef };
 
 export default Tooltip;


### PR DESCRIPTION
This type makes typescript happy about the `forceAlign` method on a tooltip ref, so I thought it would be good to go on and export it.

This makes [this example](https://github.com/react-component/slider/blob/9d9fb1ab4c0d58a725985d19f1e1011910bb6c96/docs/examples/components/TooltipSlider.tsx#L25) compile in typescript.