### PR TITLE
feat: supports classnames & styles

### DIFF
--- a/src/Popup.tsx
+++ b/src/Popup.tsx
@@ -8,20 +8,20 @@ export interface ContentProps {
   overlayInnerStyle?: React.CSSProperties;
   className?: string;
   style?: React.CSSProperties;
-  overlayInnerClassName?: string;
+  innerClassName?: string;
 }
 
 export default function Popup(props: ContentProps) {
-  const { children, prefixCls, id, overlayInnerStyle, overlayInnerClassName, className, style } =
+  const { children, prefixCls, id, overlayInnerStyle: innerStyle, innerClassName, className, style } =
     props;
 
   return (
     <div className={classNames(`${prefixCls}-content`, className)} style={style}>
       <div
-        className={classNames(`${prefixCls}-inner`, overlayInnerClassName)}
+        className={classNames(`${prefixCls}-inner`, innerClassName)}
         id={id}
         role="tooltip"
-        style={overlayInnerStyle}
+        style={innerStyle}
       >
         {typeof children === 'function' ? children() : children}
       </div>

--- a/src/Popup.tsx
+++ b/src/Popup.tsx
@@ -8,14 +8,21 @@ export interface ContentProps {
   overlayInnerStyle?: React.CSSProperties;
   className?: string;
   style?: React.CSSProperties;
+  overlayInnerClassName?: string;
 }
 
 export default function Popup(props: ContentProps) {
-  const { children, prefixCls, id, overlayInnerStyle, className, style } = props;
+  const { children, prefixCls, id, overlayInnerStyle, overlayInnerClassName, className, style } =
+    props;
 
   return (
     <div className={classNames(`${prefixCls}-content`, className)} style={style}>
-      <div className={`${prefixCls}-inner`} id={id} role="tooltip" style={overlayInnerStyle}>
+      <div
+        className={classNames(`${prefixCls}-inner`, overlayInnerClassName)}
+        id={id}
+        role="tooltip"
+        style={overlayInnerStyle}
+      >
         {typeof children === 'function' ? children() : children}
       </div>
     </div>

--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { forwardRef, useImperativeHandle, useRef } from 'react';
 import { placements } from './placements';
 import Popup from './Popup';
+import classNames from 'classnames';
 
 export interface TooltipProps
   extends Pick<
@@ -42,6 +43,18 @@ export interface TooltipProps
   id?: string;
   overlayInnerStyle?: React.CSSProperties;
   zIndex?: number;
+  styles?: TootipStyles;
+  classNames?: TooltipClassNames;
+}
+
+export interface TootipStyles {
+  root?: React.CSSProperties;
+  inner?: React.CSSProperties;
+}
+
+export interface TooltipClassNames {
+  root?: string;
+  inner?: string;
 }
 
 export interface TooltipRef extends TriggerRef {}
@@ -70,6 +83,8 @@ const Tooltip = (props: TooltipProps, ref: React.Ref<TooltipRef>) => {
     overlay,
     id,
     showArrow = true,
+    classNames: tooltipClassNames,
+    styles: tooltipStyles,
     ...restProps
   } = props;
 
@@ -82,14 +97,20 @@ const Tooltip = (props: TooltipProps, ref: React.Ref<TooltipRef>) => {
   }
 
   const getPopupElement = () => (
-    <Popup key="content" prefixCls={prefixCls} id={id} overlayInnerStyle={overlayInnerStyle}>
+    <Popup
+      key="content"
+      prefixCls={prefixCls}
+      id={id}
+      overlayInnerClassName={tooltipClassNames?.inner}
+      overlayInnerStyle={{ ...overlayInnerStyle, ...tooltipStyles?.inner }}
+    >
       {overlay}
     </Popup>
   );
 
   return (
     <Trigger
-      popupClassName={overlayClassName}
+      popupClassName={classNames(overlayClassName, tooltipClassNames?.root)}
       prefixCls={prefixCls}
       popup={getPopupElement}
       action={trigger}
@@ -106,7 +127,7 @@ const Tooltip = (props: TooltipProps, ref: React.Ref<TooltipRef>) => {
       defaultPopupVisible={defaultVisible}
       autoDestroy={destroyTooltipOnHide}
       mouseLeaveDelay={mouseLeaveDelay}
-      popupStyle={overlayStyle}
+      popupStyle={{ ...overlayStyle, ...tooltipStyles?.root }}
       mouseEnterDelay={mouseEnterDelay}
       arrow={showArrow}
       {...extraProps}

--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -101,7 +101,7 @@ const Tooltip = (props: TooltipProps, ref: React.Ref<TooltipRef>) => {
       key="content"
       prefixCls={prefixCls}
       id={id}
-      overlayInnerClassName={tooltipClassNames?.inner}
+      innerClassName={tooltipClassNames?.inner}
       overlayInnerStyle={{ ...overlayInnerStyle, ...tooltipStyles?.inner }}
     >
       {overlay}

--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -43,11 +43,11 @@ export interface TooltipProps
   id?: string;
   overlayInnerStyle?: React.CSSProperties;
   zIndex?: number;
-  styles?: TootipStyles;
+  styles?: TooltipStyles;
   classNames?: TooltipClassNames;
 }
 
-export interface TootipStyles {
+export interface TooltipStyles {
   root?: React.CSSProperties;
   inner?: React.CSSProperties;
 }

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -268,18 +268,15 @@ describe('rc-tooltip', () => {
       </Tooltip>,
     );
 
-    const tooltipElement = container.querySelector('.rc-tooltip');
-    const tooltipInnerElement = container.querySelector('.rc-tooltip-inner');
+    const tooltipElement = container.querySelector('.rc-tooltip') as HTMLElement;
+    const tooltipInnerElement = container.querySelector('.rc-tooltip-inner') as HTMLElement;
 
     // 验证 classNames
     expect(tooltipElement.classList).toContain('custom-root');
     expect(tooltipInnerElement.classList).toContain('custom-inner');
 
     // 验证 styles
-    const tooltipElementStyle = getComputedStyle(tooltipElement);
-    const tooltipInnerElementStyle = getComputedStyle(tooltipInnerElement);
-
-    expect(tooltipElementStyle.backgroundColor).toBe('blue');
-    expect(tooltipInnerElementStyle.color).toBe('red');
+    expect(tooltipElement.style.backgroundColor).toBe('blue');
+    expect(tooltipInnerElement.style.color).toBe('red');
   });
 });

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -251,4 +251,35 @@ describe('rc-tooltip', () => {
 
     expect(nodeRef.current.nativeElement).toBe(container.querySelector('button'));
   });
+  it('should apply custom styles to Tooltip', () => {
+    const customClassNames = {
+      inner: 'custom-inner',
+      root: 'custom-root',
+    };
+
+    const customStyles = {
+      inner: { color: 'red' },
+      root: { backgroundColor: 'blue' },
+    };
+
+    const { container } = render(
+      <Tooltip classNames={customClassNames} overlay={<div />} styles={customStyles} visible>
+        <button />
+      </Tooltip>,
+    );
+
+    const tooltipElement = container.querySelector('.rc-tooltip');
+    const tooltipInnerElement = container.querySelector('.rc-tooltip-inner');
+
+    // 验证 classNames
+    expect(tooltipElement.classList).toContain('custom-root');
+    expect(tooltipInnerElement.classList).toContain('custom-inner');
+
+    // 验证 styles
+    const tooltipElementStyle = getComputedStyle(tooltipElement);
+    const tooltipInnerElementStyle = getComputedStyle(tooltipInnerElement);
+
+    expect(tooltipElementStyle.backgroundColor).toBe('blue');
+    expect(tooltipInnerElementStyle.color).toBe('red');
+  });
 });


### PR DESCRIPTION
https://github.com/ant-design/ant-design/pull/51814


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 更新后的版本说明

- **新功能**
	- 在 `Popup` 组件中添加了可选属性 `innerClassName`，增强了内层覆盖层的样式灵活性。
	- 在 `Tooltip` 组件中添加了 `styles` 和 `classNames` 属性，允许用户自定义工具提示的样式和类名。

- **测试**
	- 为 `Tooltip` 组件添加了新测试用例，以验证自定义样式和类名的应用。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->