### PR TITLE
type: add deprecated info

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Online demo: <https://react-component.github.io/tooltip/demo>
 | onVisibleChange      | (visible: boolean) => void;               |                     | Callback when visible change                                                                                                                                     |
 | afterVisibleChange   | (visible: boolean) => void;               |                     | Callback after visible change                                                                                                                                    |
 | overlay              | ReactNode \| () => ReactNode              |                     | tooltip overlay content                                                                                                                                          |
-| overlayStyle         | object                                    |                     | style of tooltip overlay                                                                                                                                         |
+| overlayStyle         | object                                    |                     | deprecated, Please use `styles={{ root: {} }}`                                                                                                                                         |
 | overlayClassName     | string                                    |                     | className of tooltip overlay                                                                                                                                     |
 | prefixCls            | string                                    | 'rc-tooltip'        | prefix class name of tooltip                                                                                                                                     |
 | mouseEnterDelay      | number                                    | 0                   | delay time (in second) before tooltip shows when mouse enter                                                                                                     |
@@ -92,6 +92,8 @@ Online demo: <https://react-component.github.io/tooltip/demo>
 | align                | object                                    |                     | align config of tooltip. Please ref demo for usage example                                                                                                       |
 | showArrow            | boolean \| object                         | false               | whether to show arrow of tooltip                                                                                                                                 |
 | zIndex               | number                                    |                     | config popup tooltip zIndex                                                                                                                                      |
+| classNames           | classNames?: { root?: string; inner?: string;};            |                     | Semantic DOM class                                                                                                                                               |
+| styles               | styles?: {root?: React.CSSProperties;inner?: React.CSSProperties;};     |                     | Semantic DOM styles                                                                                                                                              |
 
 ## Important Note
 

--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -33,6 +33,7 @@ export interface TooltipProps
   onVisibleChange?: (visible: boolean) => void;
   afterVisibleChange?: (visible: boolean) => void;
   overlay: (() => React.ReactNode) | React.ReactNode;
+  /** @deprecated Please use `styles={{ root: {} }}` */
   overlayStyle?: React.CSSProperties;
   overlayClassName?: string;
   getTooltipContainer?: (node: HTMLElement) => HTMLElement;
@@ -41,6 +42,7 @@ export interface TooltipProps
   showArrow?: boolean | ArrowType;
   arrowContent?: React.ReactNode;
   id?: string;
+  /** @deprecated Please use `styles={{ inner: {} }}` */
   overlayInnerStyle?: React.CSSProperties;
   zIndex?: number;
   styles?: TooltipStyles;


### PR DESCRIPTION
这里面的类型是从rc里面的
![image](https://github.com/user-attachments/assets/b71d19c0-bd24-4dba-87d8-c8f623c0cb2c)

![image](https://github.com/user-attachments/assets/da3be8a9-b3ad-4866-b09d-3cd12b48548d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 引入新的 `styles` 属性用于样式定义，替代已弃用的 `overlayStyle` 和 `overlayInnerStyle` 属性。
  - 新增 `classNames` 属性，允许用户为 `root` 和 `inner` 元素指定语义化的 DOM 类名。

- **文档**
  - 更新了 API 文档，清晰指引用户使用新的样式和类名方法。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->