### PR TITLE
feat: retire deprecated api

### DIFF
--- a/docs/examples/formError.tsx
+++ b/docs/examples/formError.tsx
@@ -34,7 +34,7 @@ class Test extends Component {
         <div style={{ marginTop: 100, marginLeft: 100, marginBottom: 100 }}>
           <Tooltip
             visible={this.state.visible}
-            animation="zoom"
+            motion={{ motionName: 'rc-tooltip-zoom' }}
             trigger={[]}
             overlayStyle={{ zIndex: 1000 }}
             overlay={<span>required!</span>}

--- a/docs/examples/onVisibleChange.tsx
+++ b/docs/examples/onVisibleChange.tsx
@@ -7,9 +7,9 @@ function preventDefault(e) {
 }
 
 interface TestState {
-    visible: boolean;
-    destroy?: boolean;
-  }
+  visible: boolean;
+  destroy?: boolean;
+}
 
 class Test extends Component {
   state = {
@@ -37,7 +37,7 @@ class Test extends Component {
         <div style={{ marginTop: 300, marginLeft: 100, marginBottom: 100 }}>
           <Tooltip
             visible={this.state.visible}
-            animation="zoom"
+            motion={{ motionName: 'rc-tooltip-zoom' }}
             onVisibleChange={this.onVisibleChange}
             trigger="click"
             overlay={<span>I am a tooltip</span>}

--- a/docs/examples/simple.tsx
+++ b/docs/examples/simple.tsx
@@ -216,7 +216,7 @@ class Test extends Component<any, TestState> {
             align={{
               offset: [this.state.offsetX, this.state.offsetY],
             }}
-            transitionName={this.state.transitionName}
+            motion={{ motionName: this.state.transitionName }}
             overlayInnerStyle={state.overlayInnerStyle}
           >
             <div style={{ height: 100, width: 100, border: '1px solid red' }}>trigger</div>

--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -1,6 +1,6 @@
 import type { ArrowType, TriggerProps, TriggerRef } from '@rc-component/trigger';
 import Trigger from '@rc-component/trigger';
-import type { ActionType, AlignType, AnimationType } from '@rc-component/trigger/lib/interface';
+import type { ActionType, AlignType } from '@rc-component/trigger/lib/interface';
 import classNames from 'classnames';
 import * as React from 'react';
 import { forwardRef, useImperativeHandle, useRef } from 'react';
@@ -25,10 +25,6 @@ export interface TooltipProps
   defaultVisible?: boolean;
   visible?: boolean;
   placement?: string;
-  /** @deprecated Use `motion` instead */
-  transitionName?: string;
-  /** @deprecated Use `motion` instead */
-  animation?: AnimationType;
   /** Config popup motion */
   motion?: TriggerProps['popupMotion'];
   onVisibleChange?: (visible: boolean) => void;
@@ -74,8 +70,6 @@ const Tooltip = (props: TooltipProps, ref: React.Ref<TooltipRef>) => {
     children,
     onVisibleChange,
     afterVisibleChange,
-    transitionName,
-    animation,
     motion,
     placement = 'right',
     align = {},
@@ -139,8 +133,6 @@ const Tooltip = (props: TooltipProps, ref: React.Ref<TooltipRef>) => {
       getPopupContainer={getTooltipContainer}
       onPopupVisibleChange={onVisibleChange}
       afterPopupVisibleChange={afterVisibleChange}
-      popupTransitionName={transitionName}
-      popupAnimation={animation}
       popupMotion={motion}
       defaultPopupVisible={defaultVisible}
       autoDestroy={destroyTooltipOnHide}


### PR DESCRIPTION
- ref https://github.com/ant-design/ant-design/issues/52115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了 Tooltip 组件的动画处理方式
	- 从使用 `animation` 和 `transitionName` 属性改为使用更灵活的 `motion` 属性

- **重构**
	- 移除了已弃用的 `animation` 和 `transitionName` 属性
	- 简化了 Tooltip 组件的属性接口

- **文档**
	- 更新了示例代码以展示新的动画配置方法

<!-- end of auto-generated comment: release notes by coderabbit.ai -->