### PR TITLE
chore: bump util & build version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "rc-tooltip",
-  "version": "6.4.0",
+  "name": "@rc-component/tooltip",
+  "version": "1.0.0-0",
   "description": "React Tooltip",
   "keywords": [
     "react",
@@ -45,11 +45,9 @@
     "@rc-component/father-plugin": "^2.0.1",
     "@rc-component/trigger": "^2.0.0",
     "@rc-component/util": "^1.0.1",
-    "classnames": "^2.3.1",
-    "rc-util": "^5.44.3"
+    "classnames": "^2.3.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^1.0.0",
     "@testing-library/react": "^14.0.0",
     "@types/jest": "^29.4.0",
     "@types/react": "^18.0.26",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.11.2",
+    "@rc-component/father-plugin": "^2.0.1",
     "@rc-component/trigger": "^2.0.0",
+    "@rc-component/util": "^1.0.1",
     "classnames": "^2.3.1",
     "rc-util": "^5.44.3"
   },

--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -1,12 +1,12 @@
 import type { ArrowType, TriggerProps, TriggerRef } from '@rc-component/trigger';
 import Trigger from '@rc-component/trigger';
 import type { ActionType, AlignType } from '@rc-component/trigger/lib/interface';
+import useId from '@rc-component/util/lib/hooks/useId';
 import classNames from 'classnames';
 import * as React from 'react';
 import { forwardRef, useImperativeHandle, useRef } from 'react';
 import { placements } from './placements';
 import Popup from './Popup';
-import useId from 'rc-util/lib/hooks/useId';
 
 export interface TooltipProps
   extends Pick<
@@ -57,7 +57,7 @@ export interface TooltipClassNames {
   body?: string;
 }
 
-export interface TooltipRef extends TriggerRef { }
+export interface TooltipRef extends TriggerRef {}
 
 const Tooltip = (props: TooltipProps, ref: React.Ref<TooltipRef>) => {
   const {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重大更新**
	- 包名从 `rc-tooltip` 更改为 `@rc-component/tooltip`
	- 版本号重置为 `1.0.0-0`

- **依赖变更**
	- 新增依赖 `@rc-component/father-plugin` 和 `@rc-component/util`
	- 移除依赖 `rc-util`

- **代码调整**
	- 更新 `useId` 钩子的导入路径
	- 调整 `TooltipRef` 接口的格式

<!-- end of auto-generated comment: release notes by coderabbit.ai -->