### PR TITLE
chore: move @rc-component/father-plugin to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
     "test": "rc-test"
   },
   "dependencies": {
-    "@rc-component/father-plugin": "^2.0.1",
     "@rc-component/trigger": "^3.0.0",
     "@rc-component/util": "^1.0.1",
     "classnames": "^2.3.1"
   },
   "devDependencies": {
+    "@rc-component/father-plugin": "^2.0.1",
     "@rc-component/np": "^1.0.3",
     "@testing-library/react": "^16.3.0",
     "@types/jest": "^29.4.0",


### PR DESCRIPTION
https://github.com/ant-design/ant-design/issues/52115#issuecomment-3199324105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 杂务
  - 调整依赖分类：将 @rc-component/father-plugin 移至开发依赖。
  - 对终端用户无可见变化；功能与运行不受影响，生产环境安装可能更精简。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->