### PR TITLE
fix: typo

### DIFF
--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -32,7 +32,7 @@ export interface TooltipProps
   overlay: (() => React.ReactNode) | React.ReactNode;
   /** @deprecated Please use `styles={{ root: {} }}` */
   overlayStyle?: React.CSSProperties;
-  /** @deprecated Please use `classNames={{ root: {} }}` */
+  /** @deprecated Please use `classNames={{ root: '' }}` */
   overlayClassName?: string;
   getTooltipContainer?: (node: HTMLElement) => HTMLElement;
   destroyOnHidden?: boolean;


### PR DESCRIPTION
classNames 中的 root 的值应该是字符串，而不是对象

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 文档
  - 更新 TooltipProps.overlayClassName 注释，将弃用示例由 classNames={{ root: {} }} 更正为 classNames={{ root: '' }}，明确推荐写法并提升可读性。
  - 不影响运行时行为或类型签名，无需用户迁移或额外操作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->