### PR TITLE
refactor: remove useless structure

### DIFF
--- a/docs/examples/formError.tsx
+++ b/docs/examples/formError.tsx
@@ -34,7 +34,7 @@ class Test extends Component {
             visible={this.state.visible}
             motion={{ motionName: 'rc-tooltip-zoom' }}
             trigger={[]}
-            overlayStyle={{ zIndex: 1000 }}
+            styles={{ root: { zIndex: 1000 } }}
             overlay={<span>required!</span>}
           >
             <input onChange={this.handleChange} />

--- a/docs/examples/placement.tsx
+++ b/docs/examples/placement.tsx
@@ -94,8 +94,8 @@ const Test: React.FC = () => (
       <h5>Debug Usage</h5>
       <Popup
         prefixCls="rc-tooltip"
-        className="rc-tooltip-placement-top"
-        style={{ display: 'inline-block', position: 'relative' }}
+        classNames={{ body: 'rc-tooltip-placement-top' }}
+        styles={{ body: { display: 'inline-block', position: 'relative' } }}
       >
         Test
       </Popup>

--- a/docs/examples/point.tsx
+++ b/docs/examples/point.tsx
@@ -30,7 +30,7 @@ const Test: React.FC = () => {
           <Tooltip
             placement="top"
             overlay={text}
-            overlayInnerStyle={{ width: 300, height: 50 }}
+            styles={{ body: { width: 300, height: 50 } }}
             popupVisible
             arrowContent={<div className="rc-tooltip-arrow-inner" />}
           >

--- a/docs/examples/simple.tsx
+++ b/docs/examples/simple.tsx
@@ -217,7 +217,7 @@ class Test extends Component<any, TestState> {
               offset: [this.state.offsetX, this.state.offsetY],
             }}
             motion={{ motionName: this.state.transitionName }}
-            overlayInnerStyle={state.overlayInnerStyle}
+            styles={{ body: state.overlayInnerStyle }}
           >
             <div style={{ height: 100, width: 100, border: '1px solid red' }}>trigger</div>
           </Tooltip>

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test": "rc-test"
   },
   "dependencies": {
-    "@rc-component/trigger": "^3.6.0",
+    "@rc-component/trigger": "^3.6.4",
     "@rc-component/util": "^1.3.0",
     "classnames": "^2.3.1"
   },

--- a/src/Popup.tsx
+++ b/src/Popup.tsx
@@ -12,26 +12,16 @@ export interface ContentProps {
 }
 
 const Popup: React.FC<ContentProps> = (props) => {
-  const {
-    children,
-    prefixCls,
-    id,
-    overlayInnerStyle: innerStyle,
-    bodyClassName,
-    className,
-    style,
-  } = props;
+  const { children, prefixCls, id, className, style, bodyClassName, overlayInnerStyle } = props;
 
   return (
-    <div className={classNames(`${prefixCls}-content`, className)} style={style}>
-      <div
-        className={classNames(`${prefixCls}-inner`, bodyClassName)}
-        id={id}
-        role="tooltip"
-        style={innerStyle}
-      >
-        {typeof children === 'function' ? children() : children}
-      </div>
+    <div
+      id={id}
+      className={classNames(`${prefixCls}-body`, className, bodyClassName)}
+      style={{ ...overlayInnerStyle, ...style }}
+      role="tooltip"
+    >
+      {typeof children === 'function' ? children() : children}
     </div>
   );
 };

--- a/src/Popup.tsx
+++ b/src/Popup.tsx
@@ -17,7 +17,7 @@ const Popup: React.FC<ContentProps> = (props) => {
     <div
       id={id}
       className={cls(`${prefixCls}-body`, classNames?.body)}
-      style={styles.body}
+      style={styles?.body}
       role="tooltip"
     >
       {typeof children === 'function' ? children() : children}

--- a/src/Popup.tsx
+++ b/src/Popup.tsx
@@ -1,24 +1,23 @@
-import classNames from 'classnames';
+import cls from 'classnames';
 import * as React from 'react';
+import type { TooltipProps } from './Tooltip';
 
 export interface ContentProps {
   prefixCls?: string;
   children: (() => React.ReactNode) | React.ReactNode;
   id?: string;
-  overlayInnerStyle?: React.CSSProperties;
-  className?: string;
-  style?: React.CSSProperties;
-  bodyClassName?: string;
+  classNames?: TooltipProps['classNames'];
+  styles?: TooltipProps['styles'];
 }
 
 const Popup: React.FC<ContentProps> = (props) => {
-  const { children, prefixCls, id, className, style, bodyClassName, overlayInnerStyle } = props;
+  const { children, prefixCls, id, classNames, styles } = props;
 
   return (
     <div
       id={id}
-      className={classNames(`${prefixCls}-body`, className, bodyClassName)}
-      style={{ ...overlayInnerStyle, ...style }}
+      className={cls(`${prefixCls}-body`, classNames?.body)}
+      style={styles.body}
       role="tooltip"
     >
       {typeof children === 'function' ? children() : children}

--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -107,9 +107,10 @@ const Tooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) => {
     return {
       ...arrowConfig,
       className: cls(arrowConfig.className, classNames?.arrow),
-      content: arrowConfig.content || arrowContent,
+      style: { ...arrowConfig.style, ...styles?.arrow },
+      content: arrowConfig.content ?? arrowContent,
     };
-  }, [showArrow, classNames?.arrow, arrowContent]);
+  }, [showArrow, classNames?.arrow, styles?.arrow, arrowContent]);
 
   // ======================== Children ========================
   const getChildren = () => {

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -368,11 +368,9 @@ describe('rc-tooltip', () => {
       const tooltipArrowElement = container.querySelector('.rc-tooltip-arrow') as HTMLElement;
 
       // Verify styles
-      expect(tooltipElement.style.backgroundColor).toBe('blue');
-      expect(tooltipElement.style.zIndex).toBe('1000');
-      expect(tooltipBodyElement.style.color).toBe('red');
-      expect(tooltipBodyElement.style.fontSize).toBe('14px');
-      expect(tooltipArrowElement.style.borderColor).toBe('green');
+      expect(tooltipElement).toHaveStyle({ backgroundColor: 'blue', zIndex: '1000' });
+      expect(tooltipBodyElement).toHaveStyle({ color: 'red', fontSize: '14px' });
+      expect(tooltipArrowElement).toHaveStyle({ borderColor: 'green' });
     });
 
     it('should apply both classNames and styles simultaneously', () => {
@@ -406,11 +404,11 @@ describe('rc-tooltip', () => {
 
       // Verify that classNames and styles work simultaneously
       expect(tooltipElement).toHaveClass('custom-root');
-      expect(tooltipElement.style.backgroundColor).toBe('blue');
+      expect(tooltipElement).toHaveStyle({ backgroundColor: 'blue' });
       expect(tooltipBodyElement).toHaveClass('custom-body');
-      expect(tooltipBodyElement.style.color).toBe('red');
+      expect(tooltipBodyElement).toHaveStyle({ color: 'red' });
       expect(tooltipArrowElement).toHaveClass('custom-arrow');
-      expect(tooltipArrowElement.style.borderColor).toBe('green');
+      expect(tooltipArrowElement).toHaveStyle({ borderColor: 'green' });
     });
 
     it('should work with partial classNames and styles', () => {
@@ -439,7 +437,7 @@ describe('rc-tooltip', () => {
       const tooltipArrowElement = container.querySelector('.rc-tooltip-arrow') as HTMLElement;
 
       // Verify partial configuration takes effect
-      expect(tooltipElement.style.backgroundColor).toBe('blue');
+      expect(tooltipElement).toHaveStyle({ backgroundColor: 'blue' });
       expect(tooltipBodyElement).toHaveClass('custom-body');
       
       // Verify that unconfigured elements don't have custom class names or styles
@@ -481,9 +479,9 @@ describe('rc-tooltip', () => {
       
       // Other styles still take effect
       expect(tooltipElement).toHaveClass('custom-root');
-      expect(tooltipElement.style.backgroundColor).toBe('blue');
+      expect(tooltipElement).toHaveStyle({ backgroundColor: 'blue' });
       expect(tooltipBodyElement).toHaveClass('custom-body');
-      expect(tooltipBodyElement.style.color).toBe('red');
+      expect(tooltipBodyElement).toHaveStyle({ color: 'red' });
     });
   });
 

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render } from '@testing-library/react';
 import React from 'react';
-import Tooltip, { TooltipRef } from '../src';
+import Tooltip, { type TooltipRef } from '../src';
 
 const verifyContent = (wrapper: HTMLElement, content: string) => {
   expect(wrapper.querySelector('.x-content').textContent).toBe(content);
@@ -73,7 +73,7 @@ describe('rc-tooltip', () => {
       );
       fireEvent.click(container.querySelector('.target'));
       expect(
-        (container.querySelector('.rc-tooltip-inner') as HTMLElement).style.background,
+        (container.querySelector('.rc-tooltip-body') as HTMLElement).style.background,
       ).toEqual('red');
     });
 
@@ -269,11 +269,11 @@ describe('rc-tooltip', () => {
     );
 
     const tooltipElement = container.querySelector('.rc-tooltip') as HTMLElement;
-    const tooltipBodyElement = container.querySelector('.rc-tooltip-inner') as HTMLElement;
+    const tooltipBodyElement = container.querySelector('.rc-tooltip-body') as HTMLElement;
 
     // 验证 classNames
-    expect(tooltipElement.classList).toContain('custom-root');
-    expect(tooltipBodyElement.classList).toContain('custom-body');
+    expect(tooltipElement).toHaveClass('custom-root');
+    expect(tooltipBodyElement).toHaveClass('custom-body');
 
     // 验证 styles
     expect(tooltipElement.style.backgroundColor).toBe('blue');

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -59,23 +59,7 @@ describe('rc-tooltip', () => {
       verifyContent(container, 'Tooltip content');
     });
 
-    // https://github.com/ant-design/ant-design/pull/23155
-    it('using style inner style', () => {
-      const { container } = render(
-        <Tooltip
-          trigger={['click']}
-          placement="left"
-          overlay={() => <strong className="x-content">Tooltip content</strong>}
-          overlayInnerStyle={{ background: 'red' }}
-        >
-          <div className="target">Click this</div>
-        </Tooltip>,
-      );
-      fireEvent.click(container.querySelector('.target'));
-      expect(
-        (container.querySelector('.rc-tooltip-body') as HTMLElement).style.background,
-      ).toEqual('red');
-    });
+
 
     it('access of ref', () => {
       const domRef = React.createRef<TooltipRef>();
@@ -216,6 +200,87 @@ describe('rc-tooltip', () => {
       );
       expect(container.querySelector('.rc-tooltip-arrow')).toBeFalsy();
     });
+
+    it('should merge arrow className from showArrow and classNames.arrow', () => {
+      const { container } = render(
+        <Tooltip
+          trigger={['click']}
+          placement="left"
+          overlay={<strong className="x-content">Tooltip content</strong>}
+          showArrow={{
+            className: 'from-showArrow',
+          }}
+          classNames={{
+            arrow: 'from-classNames',
+          }}
+          visible
+        >
+          <div className="target">Click this</div>
+        </Tooltip>,
+      );
+
+      const arrowElement = container.querySelector('.rc-tooltip-arrow');
+      expect(arrowElement).toHaveClass('from-showArrow');
+      expect(arrowElement).toHaveClass('from-classNames');
+    });
+
+    it('should use arrowContent from showArrow object', () => {
+      const { container } = render(
+        <Tooltip
+          trigger={['click']}
+          placement="left"
+          overlay={<strong className="x-content">Tooltip content</strong>}
+          showArrow={{
+            content: <span className="custom-arrow-content">↑</span>,
+          }}
+          visible
+        >
+          <div className="target">Click this</div>
+        </Tooltip>,
+      );
+
+      expect(container.querySelector('.custom-arrow-content')).toBeTruthy();
+      expect(container.querySelector('.custom-arrow-content').textContent).toBe('↑');
+    });
+
+    it('should use arrowContent prop when showArrow has no content', () => {
+      const { container } = render(
+        <Tooltip
+          trigger={['click']}
+          placement="left"
+          overlay={<strong className="x-content">Tooltip content</strong>}
+          showArrow
+          arrowContent={<span className="prop-arrow-content">→</span>}
+          visible
+        >
+          <div className="target">Click this</div>
+        </Tooltip>,
+      );
+
+      expect(container.querySelector('.prop-arrow-content')).toBeTruthy();
+      expect(container.querySelector('.prop-arrow-content').textContent).toBe('→');
+    });
+
+    it('should prioritize showArrow.content over arrowContent prop', () => {
+      const { container } = render(
+        <Tooltip
+          trigger={['click']}
+          placement="left"
+          overlay={<strong className="x-content">Tooltip content</strong>}
+          showArrow={{
+            content: <span className="showArrow-content">↑</span>,
+          }}
+          arrowContent={<span className="prop-content">→</span>}
+          visible
+        >
+          <div className="target">Click this</div>
+        </Tooltip>,
+      );
+
+      expect(container.querySelector('.showArrow-content')).toBeTruthy();
+      expect(container.querySelector('.prop-content')).toBeFalsy();
+      expect(container.querySelector('.showArrow-content').textContent).toBe('↑');
+    });
   });
 
   it('visible', () => {
@@ -251,33 +316,175 @@ describe('rc-tooltip', () => {
 
     expect(nodeRef.current.nativeElement).toBe(container.querySelector('button'));
   });
-  it('should apply custom styles to Tooltip', () => {
-    const customClassNames = {
-      body: 'custom-body',
-      root: 'custom-root',
-    };
+  describe('classNames and styles', () => {
+    it('should apply custom classNames to all semantic elements', () => {
+      const customClassNames = {
+        root: 'custom-root',
+        body: 'custom-body',
+        arrow: 'custom-arrow',
+      };
 
-    const customStyles = {
-      body: { color: 'red' },
-      root: { backgroundColor: 'blue' },
-    };
+      const { container } = render(
+        <Tooltip
+          classNames={customClassNames}
+          overlay={<div>Tooltip content</div>}
+          visible
+          showArrow
+        >
+          <button>Trigger</button>
+        </Tooltip>,
+      );
 
-    const { container } = render(
-      <Tooltip classNames={customClassNames} overlay={<div />} styles={customStyles} visible>
-        <button />
-      </Tooltip>,
-    );
+      const tooltipElement = container.querySelector('.rc-tooltip') as HTMLElement;
+      const tooltipBodyElement = container.querySelector('.rc-tooltip-body') as HTMLElement;
+      const tooltipArrowElement = container.querySelector('.rc-tooltip-arrow') as HTMLElement;
 
-    const tooltipElement = container.querySelector('.rc-tooltip') as HTMLElement;
-    const tooltipBodyElement = container.querySelector('.rc-tooltip-body') as HTMLElement;
+      // 验证 classNames
+      expect(tooltipElement).toHaveClass('custom-root');
+      expect(tooltipBodyElement).toHaveClass('custom-body');
+      expect(tooltipArrowElement).toHaveClass('custom-arrow');
+    });
 
-    // 验证 classNames
-    expect(tooltipElement).toHaveClass('custom-root');
-    expect(tooltipBodyElement).toHaveClass('custom-body');
+    it('should apply custom styles to all semantic elements', () => {
+      const customStyles = {
+        root: { backgroundColor: 'blue', zIndex: 1000 },
+        body: { color: 'red', fontSize: '14px' },
+        arrow: { borderColor: 'green' },
+      };
 
-    // 验证 styles
-    expect(tooltipElement.style.backgroundColor).toBe('blue');
-    expect(tooltipBodyElement.style.color).toBe('red');
+      const { container } = render(
+        <Tooltip
+          styles={customStyles}
+          overlay={<div>Tooltip content</div>}
+          visible
+          showArrow
+        >
+          <button>Trigger</button>
+        </Tooltip>,
+      );
+
+      const tooltipElement = container.querySelector('.rc-tooltip') as HTMLElement;
+      const tooltipBodyElement = container.querySelector('.rc-tooltip-body') as HTMLElement;
+      const tooltipArrowElement = container.querySelector('.rc-tooltip-arrow') as HTMLElement;
+
+      // 验证 styles
+      expect(tooltipElement.style.backgroundColor).toBe('blue');
+      expect(tooltipElement.style.zIndex).toBe('1000');
+      expect(tooltipBodyElement.style.color).toBe('red');
+      expect(tooltipBodyElement.style.fontSize).toBe('14px');
+      expect(tooltipArrowElement.style.borderColor).toBe('green');
+    });
+
+    it('should apply both classNames and styles simultaneously', () => {
+      const customClassNames = {
+        root: 'custom-root',
+        body: 'custom-body',
+        arrow: 'custom-arrow',
+      };
+
+      const customStyles = {
+        root: { backgroundColor: 'blue' },
+        body: { color: 'red' },
+        arrow: { borderColor: 'green' },
+      };
+
+      const { container } = render(
+        <Tooltip
+          classNames={customClassNames}
+          styles={customStyles}
+          overlay={<div>Tooltip content</div>}
+          visible
+          showArrow
+        >
+          <button>Trigger</button>
+        </Tooltip>,
+      );
+
+      const tooltipElement = container.querySelector('.rc-tooltip') as HTMLElement;
+      const tooltipBodyElement = container.querySelector('.rc-tooltip-body') as HTMLElement;
+      const tooltipArrowElement = container.querySelector('.rc-tooltip-arrow') as HTMLElement;
+
+      // 验证 classNames 和 styles 同时生效
+      expect(tooltipElement).toHaveClass('custom-root');
+      expect(tooltipElement.style.backgroundColor).toBe('blue');
+      expect(tooltipBodyElement).toHaveClass('custom-body');
+      expect(tooltipBodyElement.style.color).toBe('red');
+      expect(tooltipArrowElement).toHaveClass('custom-arrow');
+      expect(tooltipArrowElement.style.borderColor).toBe('green');
+    });
+
+    it('should work with partial classNames and styles', () => {
+      const partialClassNames = {
+        body: 'custom-body',
+      };
+
+      const partialStyles = {
+        root: { backgroundColor: 'blue' },
+      };
+
+      const { container } = render(
+        <Tooltip
+          classNames={partialClassNames}
+          styles={partialStyles}
+          overlay={<div>Tooltip content</div>}
+          visible
+          showArrow
+        >
+          <button>Trigger</button>
+        </Tooltip>,
+      );
+
+      const tooltipElement = container.querySelector('.rc-tooltip') as HTMLElement;
+      const tooltipBodyElement = container.querySelector('.rc-tooltip-body') as HTMLElement;
+      const tooltipArrowElement = container.querySelector('.rc-tooltip-arrow') as HTMLElement;
+
+      // 验证部分配置生效
+      expect(tooltipElement.style.backgroundColor).toBe('blue');
+      expect(tooltipBodyElement).toHaveClass('custom-body');
+      
+      // 验证未配置的不会有自定义类名或样式
+      expect(tooltipElement).not.toHaveClass('custom-root');
+      expect(tooltipArrowElement).not.toHaveClass('custom-arrow');
+    });
+
+    it('should not break when showArrow is false', () => {
+      const customClassNames = {
+        root: 'custom-root',
+        body: 'custom-body',
+        arrow: 'custom-arrow', // 即使配置了arrow，但不显示箭头时不应该报错
+      };
+
+      const customStyles = {
+        root: { backgroundColor: 'blue' },
+        body: { color: 'red' },
+        arrow: { borderColor: 'green' },
+      };
+
+      const { container } = render(
+        <Tooltip
+          classNames={customClassNames}
+          styles={customStyles}
+          overlay={<div>Tooltip content</div>}
+          visible
+          showArrow={false}
+        >
+          <button>Trigger</button>
+        </Tooltip>,
+      );
+
+      const tooltipElement = container.querySelector('.rc-tooltip') as HTMLElement;
+      const tooltipBodyElement = container.querySelector('.rc-tooltip-body') as HTMLElement;
+      const tooltipArrowElement = container.querySelector('.rc-tooltip-arrow');
+
+      // 验证没有箭头时
+      expect(tooltipArrowElement).toBeFalsy();
+      
+      // 其他样式仍然生效
+      expect(tooltipElement).toHaveClass('custom-root');
+      expect(tooltipElement.style.backgroundColor).toBe('blue');
+      expect(tooltipBodyElement).toHaveClass('custom-body');
+      expect(tooltipBodyElement.style.color).toBe('red');
+    });
   });
 
   describe('children handling', () => {

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -339,7 +339,7 @@ describe('rc-tooltip', () => {
       const tooltipBodyElement = container.querySelector('.rc-tooltip-body') as HTMLElement;
       const tooltipArrowElement = container.querySelector('.rc-tooltip-arrow') as HTMLElement;
 
-      // 验证 classNames
+      // Verify classNames
       expect(tooltipElement).toHaveClass('custom-root');
       expect(tooltipBodyElement).toHaveClass('custom-body');
       expect(tooltipArrowElement).toHaveClass('custom-arrow');
@@ -367,7 +367,7 @@ describe('rc-tooltip', () => {
       const tooltipBodyElement = container.querySelector('.rc-tooltip-body') as HTMLElement;
       const tooltipArrowElement = container.querySelector('.rc-tooltip-arrow') as HTMLElement;
 
-      // 验证 styles
+      // Verify styles
       expect(tooltipElement.style.backgroundColor).toBe('blue');
       expect(tooltipElement.style.zIndex).toBe('1000');
       expect(tooltipBodyElement.style.color).toBe('red');
@@ -404,7 +404,7 @@ describe('rc-tooltip', () => {
       const tooltipBodyElement = container.querySelector('.rc-tooltip-body') as HTMLElement;
       const tooltipArrowElement = container.querySelector('.rc-tooltip-arrow') as HTMLElement;
 
-      // 验证 classNames 和 styles 同时生效
+      // Verify that classNames and styles work simultaneously
       expect(tooltipElement).toHaveClass('custom-root');
       expect(tooltipElement.style.backgroundColor).toBe('blue');
       expect(tooltipBodyElement).toHaveClass('custom-body');
@@ -438,11 +438,11 @@ describe('rc-tooltip', () => {
       const tooltipBodyElement = container.querySelector('.rc-tooltip-body') as HTMLElement;
       const tooltipArrowElement = container.querySelector('.rc-tooltip-arrow') as HTMLElement;
 
-      // 验证部分配置生效
+      // Verify partial configuration takes effect
       expect(tooltipElement.style.backgroundColor).toBe('blue');
       expect(tooltipBodyElement).toHaveClass('custom-body');
       
-      // 验证未配置的不会有自定义类名或样式
+      // Verify that unconfigured elements don't have custom class names or styles
       expect(tooltipElement).not.toHaveClass('custom-root');
       expect(tooltipArrowElement).not.toHaveClass('custom-arrow');
     });
@@ -476,10 +476,10 @@ describe('rc-tooltip', () => {
       const tooltipBodyElement = container.querySelector('.rc-tooltip-body') as HTMLElement;
       const tooltipArrowElement = container.querySelector('.rc-tooltip-arrow');
 
-      // 验证没有箭头时
+      // Verify when arrow is not shown
       expect(tooltipArrowElement).toBeFalsy();
       
-      // 其他样式仍然生效
+      // Other styles still take effect
       expect(tooltipElement).toHaveClass('custom-root');
       expect(tooltipElement.style.backgroundColor).toBe('blue');
       expect(tooltipBodyElement).toHaveClass('custom-body');
@@ -522,7 +522,7 @@ describe('rc-tooltip', () => {
       const btn = container.querySelector('button');
       expect(btn).toHaveClass('custom-btn');
 
-      // 触发原始事件处理器
+      // Trigger original event handler
       fireEvent.mouseEnter(btn);
       expect(onMouseEnter).toHaveBeenCalled();
     });


### PR DESCRIPTION
按照新的语义化结构裁剪 dom 层级

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 引入语义化样式 API：classNames 与 styles 按 root/arrow/body 精确定制；新增 motion 支持。
- 重构
  - 合并 Popup 内容为单层容器；统一箭头配置；样式明确应用到 body 区域。
- 废弃
  - 标记 overlayStyle/overlayClassName/overlayInnerStyle 为废弃，请迁移至新的语义化样式。
- 破坏性变更
  - 移除 TooltipStyles 与 TooltipClassNames；DOM 从 rc-tooltip-inner 调整为 rc-tooltip-body（请更新选择器）。
- 测试
  - 同步更新断言与选择器。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->