### PR TITLE
feat: semantic add uniqueBody

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test": "rc-test"
   },
   "dependencies": {
-    "@rc-component/trigger": "^3.6.4",
+    "@rc-component/trigger": "^3.6.7",
     "@rc-component/util": "^1.3.0",
     "classnames": "^2.3.1"
   },

--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -8,7 +8,7 @@ import { useImperativeHandle, useRef } from 'react';
 import { placements } from './placements';
 import Popup from './Popup';
 
-export type SemanticName = 'root' | 'arrow' | 'body';
+export type SemanticName = 'root' | 'arrow' | 'body' | 'uniqueBody';
 
 export interface TooltipProps
   extends Pick<
@@ -154,6 +154,8 @@ const Tooltip = React.forwardRef<TooltipRef, TooltipProps>((props, ref) => {
       popupStyle={styles?.root}
       mouseEnterDelay={mouseEnterDelay}
       arrow={mergedArrow}
+      uniqueBgClassName={classNames?.uniqueBody}
+      uniqueBgStyle={styles?.uniqueBody}
       {...extraProps}
     >
       {getChildren()}

--- a/tests/__mocks__/@rc-component/trigger.js
+++ b/tests/__mocks__/@rc-component/trigger.js
@@ -1,3 +1,4 @@
-import Trigger from '@rc-component/trigger/lib/mock';
+import Trigger, { UniqueProvider } from '@rc-component/trigger/lib/mock';
 
 export default Trigger;
+export { UniqueProvider };

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1,3 +1,4 @@
+import { UniqueProvider } from '@rc-component/trigger';
 import { act, fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import Tooltip, { type TooltipRef } from '../src';
@@ -58,8 +59,6 @@ describe('rc-tooltip', () => {
       fireEvent.click(container.querySelector('.target'));
       verifyContent(container, 'Tooltip content');
     });
-
-
 
     it('access of ref', () => {
       const domRef = React.createRef<TooltipRef>();
@@ -353,12 +352,7 @@ describe('rc-tooltip', () => {
       };
 
       const { container } = render(
-        <Tooltip
-          styles={customStyles}
-          overlay={<div>Tooltip content</div>}
-          visible
-          showArrow
-        >
+        <Tooltip styles={customStyles} overlay={<div>Tooltip content</div>} visible showArrow>
           <button>Trigger</button>
         </Tooltip>,
       );
@@ -439,10 +433,34 @@ describe('rc-tooltip', () => {
       // Verify partial configuration takes effect
       expect(tooltipElement).toHaveStyle({ backgroundColor: 'blue' });
       expect(tooltipBodyElement).toHaveClass('custom-body');
-      
+
       // Verify that unconfigured elements don't have custom class names or styles
       expect(tooltipElement).not.toHaveClass('custom-root');
       expect(tooltipArrowElement).not.toHaveClass('custom-arrow');
+    });
+
+    it('should pass uniqueBody to Trigger as uniqueBgClassName and uniqueBgStyle', () => {
+      // Test that the component renders without errors when uniqueBody is provided
+      render(
+        <UniqueProvider>
+          <Tooltip
+            classNames={{ uniqueBody: 'unique-body-class' }}
+            styles={{ uniqueBody: { color: 'red' } }}
+            overlay={<div>Tooltip content</div>}
+            visible
+            unique
+          >
+            <button>Trigger</button>
+          </Tooltip>
+        </UniqueProvider>,
+      );
+
+      console.log(document.body.innerHTML);
+
+      // Test that uniqueBody doesn't break the normal tooltip functionality
+      expect(document.querySelector('.unique-body-class')).toHaveStyle({
+        color: 'red',
+      });
     });
 
     it('should not break when showArrow is false', () => {
@@ -476,7 +494,7 @@ describe('rc-tooltip', () => {
 
       // Verify when arrow is not shown
       expect(tooltipArrowElement).toBeFalsy();
-      
+
       // Other styles still take effect
       expect(tooltipElement).toHaveClass('custom-root');
       expect(tooltipElement).toHaveStyle({ backgroundColor: 'blue' });

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -455,8 +455,6 @@ describe('rc-tooltip', () => {
         </UniqueProvider>,
       );
 
-      console.log(document.body.innerHTML);
-
       // Test that uniqueBody doesn't break the normal tooltip functionality
       expect(document.querySelector('.unique-body-class')).toHaveStyle({
         color: 'red',


### PR DESCRIPTION
语义化结构添加额外的滑动容器配置，支持上游 css var 传递。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - Tooltip 支持对“唯一内容”区域独立设置类名与样式，能更精细地控制提示框背景与外观。
- 依赖
  - 更新触发组件相关依赖到小版本以获取兼容性与稳定性改进。
- 测试
  - 新增覆盖“唯一内容”样式传递与渲染的测试用例，并在测试环境中公开相应的辅助提供器以支持断言。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->