### PR TITLE
Avoid rc package deep imports

### DIFF
--- a/docs/examples/simple.tsx
+++ b/docs/examples/simple.tsx
@@ -1,10 +1,11 @@
-import type { ActionType } from '@rc-component/trigger';
-import type { OffsetType } from '@rc-component/trigger/lib/interface';
+import type { ActionType, AlignType } from '@rc-component/trigger';
 import Tooltip from 'rc-tooltip';
 import type { CSSProperties } from 'react';
 import React, { Component } from 'react';
 import '../../assets/bootstrap.less';
 import { placements } from '../../src/placements';
+
+type OffsetType = NonNullable<AlignType['offset']>[number];
 
 interface TestState {
   destroyOnHidden: boolean;

--- a/docs/examples/simple.tsx
+++ b/docs/examples/simple.tsx
@@ -1,11 +1,11 @@
-import type { ActionType, AlignType } from '@rc-component/trigger';
+import type { ActionType } from '@rc-component/trigger';
 import Tooltip from 'rc-tooltip';
 import type { CSSProperties } from 'react';
 import React, { Component } from 'react';
 import '../../assets/bootstrap.less';
 import { placements } from '../../src/placements';
 
-type OffsetType = NonNullable<AlignType['offset']>[number];
+type OffsetType = string | number;
 
 interface TestState {
   destroyOnHidden: boolean;

--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
   },
   "dependencies": {
     "@rc-component/trigger": "^3.7.1",
-    "@rc-component/util": "^1.3.0",
+    "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.1",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.3",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",

--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -1,7 +1,12 @@
-import type { ArrowType, TriggerProps, TriggerRef } from '@rc-component/trigger';
+import type {
+  ActionType,
+  AlignType,
+  ArrowType,
+  TriggerProps,
+  TriggerRef,
+} from '@rc-component/trigger';
 import Trigger from '@rc-component/trigger';
-import type { ActionType, AlignType } from '@rc-component/trigger/lib/interface';
-import useId from '@rc-component/util/lib/hooks/useId';
+import { useId } from '@rc-component/util';
 import { clsx } from 'clsx';
 import * as React from 'react';
 import { useImperativeHandle, useRef } from 'react';
@@ -10,18 +15,17 @@ import Popup from './Popup';
 
 export type SemanticName = 'root' | 'arrow' | 'container' | 'uniqueContainer';
 
-export interface TooltipProps
-  extends Pick<
-    TriggerProps,
-    | 'onPopupAlign'
-    | 'builtinPlacements'
-    | 'fresh'
-    | 'mouseLeaveDelay'
-    | 'mouseEnterDelay'
-    | 'prefixCls'
-    | 'forceRender'
-    | 'popupVisible'
-  > {
+export interface TooltipProps extends Pick<
+  TriggerProps,
+  | 'onPopupAlign'
+  | 'builtinPlacements'
+  | 'fresh'
+  | 'mouseLeaveDelay'
+  | 'mouseEnterDelay'
+  | 'prefixCls'
+  | 'forceRender'
+  | 'popupVisible'
+> {
   children: React.ReactElement;
   // Style
   classNames?: Partial<Record<SemanticName, string>>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,8 @@
 import Popup from './Popup';
 import Tooltip from './Tooltip';
 
-export type { TooltipRef } from './Tooltip';
+export type { TooltipProps, TooltipRef } from './Tooltip';
+export { placements } from './placements';
 export { Popup };
 
 export default Tooltip;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,7 @@
 import Popup from './Popup';
 import Tooltip from './Tooltip';
 
-export type { TooltipProps, TooltipRef } from './Tooltip';
-export { placements } from './placements';
+export type { TooltipRef } from './Tooltip';
 export { Popup };
 
 export default Tooltip;


### PR DESCRIPTION
## 背景

antd 侧限制继续使用 rc 包的 `lib` / `es` 深路径导入，需要将 tooltip 中对 rc 包内部路径的依赖迁移到包根入口。

## 调整内容

- 升级 `@rc-component/father-plugin`，使用插件统一拦截 rc 包 `lib` / `es` 深路径导入。
- 升级 `@rc-component/util`。
- 将源码中对 `@rc-component/util` 和 `@rc-component/trigger` 内部路径的引用改为从包根入口导入。
- 调整示例中 `OffsetType` 的来源，避免继续依赖 trigger 内部 interface 路径。

## 验证

- 本次按本地核对后的改动提交。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **New Features**
  * 导出项扩展：新增导出组件的属性类型与 placements 命名导出，便于类型使用和定位配置。

* **Chores**
  * 升级若干依赖以改善兼容性与稳定性。
  * 示例与组件内调整类型引用方式并在示例中新增本地类型声明，接口与运行行为不变。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/tooltip/pull/519?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->