### PR TITLE
feat: support disabled prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Then open `http://localhost:8000`.
 | `classNames`          | `Partial<Record<SemanticName, string>>`              | -                   | Semantic class names for root, arrow, and container nodes. |
 | `defaultVisible`      | boolean                                              | -                   | Initial uncontrolled visible state.                        |
 | `destroyOnHidden`     | boolean                                              | false               | Destroy popup DOM when hidden.                             |
+| `disabled`            | boolean                                              | false               | Temporarily hide tooltip while preserving visible state.   |
 | `fresh`               | boolean                                              | -                   | Keep popup content fresh when closed.                      |
 | `getTooltipContainer` | `(node: HTMLElement) => HTMLElement`                 | -                   | Resolve popup container.                                   |
 | `id`                  | string                                               | generated id        | Tooltip id used for accessibility.                         |

--- a/docs/demo/disabled.md
+++ b/docs/demo/disabled.md
@@ -1,0 +1,12 @@
+---
+title: Disabled
+order: 9
+---
+
+Hover the button to show the Tooltip. Click it to toggle `disabled`.
+
+```jsx
+import DisabledDemo from '../examples/disabled';
+
+export default () => <DisabledDemo />;
+```

--- a/docs/examples/disabled.tsx
+++ b/docs/examples/disabled.tsx
@@ -1,0 +1,19 @@
+import React, { useState } from 'react';
+import '../../assets/bootstrap.less';
+import Tooltip from '../../src';
+
+const DisabledDemo = () => {
+  const [disabled, setDisabled] = useState(false);
+
+  return (
+    <div style={{ margin: 100 }}>
+      <Tooltip disabled={disabled} overlay="Tooltip content" placement="top">
+        <button type="button" onClick={() => setDisabled((value) => !value)}>
+          {disabled ? 'Enable Tooltip' : 'Disable Tooltip'}
+        </button>
+      </Tooltip>
+    </div>
+  );
+};
+
+export default DisabledDemo;

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@rc-component/trigger": "^3.7.1",
+    "@rc-component/trigger": "^3.10.0",
     "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },

--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -19,6 +19,7 @@ export interface TooltipProps extends Pick<
   TriggerProps,
   | 'onPopupAlign'
   | 'builtinPlacements'
+  | 'disabled'
   | 'fresh'
   | 'mouseLeaveDelay'
   | 'mouseEnterDelay'

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -304,6 +304,32 @@ describe('rc-tooltip', () => {
     expect(container.querySelector('.x-content')).toBeTruthy();
   });
 
+  it('temporarily hides while disabled and restores without mouse leave', () => {
+    const App = () => {
+      const [disabled, setDisabled] = React.useState(false);
+
+      return (
+        <Tooltip disabled={disabled} overlay="Tooltip content">
+          <button type="button" onClick={() => setDisabled((value) => !value)}>
+            Toggle disabled
+          </button>
+        </Tooltip>
+      );
+    };
+
+    const { container } = render(<App />);
+    const button = container.querySelector('button');
+
+    fireEvent.mouseEnter(button);
+    expect(container.querySelector('.rc-tooltip')).not.toHaveClass('rc-tooltip-hidden');
+
+    fireEvent.click(button);
+    expect(container.querySelector('.rc-tooltip')).toHaveClass('rc-tooltip-hidden');
+
+    fireEvent.click(button);
+    expect(container.querySelector('.rc-tooltip')).not.toHaveClass('rc-tooltip-hidden');
+  });
+
   it('ref support nativeElement', () => {
     const nodeRef = React.createRef<TooltipRef>();
 


### PR DESCRIPTION
## Summary

- expose `disabled` through `TooltipProps` and pass it to Trigger
- require `@rc-component/trigger@^3.10.0`
- add API documentation, coverage, and an interactive disabled demo

## Behavior

Hovering opens the Tooltip. Toggling `disabled` hides it without resetting the current open state, so enabling it again restores the Tooltip without another mouse enter.

Related: https://github.com/react-component/trigger/pull/638

## Validation

- `ut test --runInBand` (2 suites, 28 tests)
- `./node_modules/.bin/tsc --noEmit`
- `ut lint` (no errors; one existing warning)
- `ut compile`
- `ut docs:build`
- `ut x prettier@3.6.2 --check package.json src/Tooltip.tsx tests/index.test.tsx docs/examples/disabled.tsx docs/demo/disabled.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - Tooltip 新增 `disabled` 属性，可临时隐藏提示内容，并支持重新启用。
  - 增加禁用状态示例及交互演示。
- **文档**
  - 补充 Tooltip API 中 `disabled` 参数的说明，包括类型和默认值。
- **修复**
  - 切换为禁用状态时，Tooltip 可立即隐藏；重新启用后可恢复显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->